### PR TITLE
if grafana version has changed, actually deletes the /tmp/grafana.deb…

### DIFF
--- a/lib/facter/grafana_version.rb
+++ b/lib/facter/grafana_version.rb
@@ -1,0 +1,7 @@
+if  FileTest.exists?("/usr/bin/dpkg-query")
+	Facter.add("grafana_version") do
+		setcode do
+			%x{/usr/bin/dpkg-query -W -f='${Version}' grafana}
+		end
+	end
+end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,6 +26,12 @@ class grafana::install {
             source   => '/tmp/grafana.deb',
             require  => [Wget::Fetch['grafana'],Package['libfontconfig1']]
           }
+          # if using 'latest' keyword version, this will run all the time
+          if $grafana_version != $::grafana::version {
+            file { '/tmp/grafana.deb':
+              ensure   => absent
+            }
+          }
         }
         'RedHat': {
           package { 'fontconfig':


### PR DESCRIPTION
… package and install the new one.
Otherwise, you will have to manually delete /tmp/grafana.deb to install a newer/different version
